### PR TITLE
Add product category routes with CRUD operations and file upload support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .env
+x.js
+folderStructure.txt

--- a/server/app.js
+++ b/server/app.js
@@ -13,9 +13,11 @@ app.use(bodyParser.json());
 
 // Importing routes
 import userRouter from './routes/user.routes.js';
+import productCategoryRouter from './routes/Product/productCategory.route.js';
 
 //TODO: Add your routes here
 app.use('/api/account/user', userRouter);
+app.use('/api/products/category', productCategoryRouter);
 
 
 

--- a/server/controllers/product/productCategory.controllers.js
+++ b/server/controllers/product/productCategory.controllers.js
@@ -1,0 +1,362 @@
+import mongoose from "mongoose";
+import {
+  deleteFromCloudinary,
+  uploadOnCloudinary,
+} from "../../lib/cloudinary.js";
+import Category from "../../models/Product/productCategory.model.js";
+import slugify from "slugify";
+
+const createCategory = async (req, res) => {
+  try {
+    const {
+      category_name,
+      category_url,
+      editor,
+      meta_description,
+      meta_title,
+      meta_keywords,
+      parent_category,
+      status,
+    } = req.body;
+
+    // Validate required fields
+    if (!category_name || !category_url) {
+      return res.status(400).json({
+        status: "failed",
+        error: "Category name and URL are required",
+      });
+    }
+
+    // Check for duplicate category name and URL
+    const isNameAvailable = await checkIfCategoryExists("name", category_name);
+    if (!isNameAvailable) {
+      return res.status(409).json({
+        status: "failed",
+        error: {
+          name: {
+            message: "Category with this name already exists",
+            path: "name",
+          },
+        },
+      });
+    }
+    const isUrlAvailable = await checkIfCategoryExists("url", category_url);
+    if (!isUrlAvailable) {
+      return res.status(409).json({
+        status: "failed",
+        error: {
+          url: {
+            message: "Category with this URL already exists",
+            path: "url",
+          },
+        },
+      });
+    }
+
+    // Handle file upload
+    const bannerLocalPath = req.files?.banner?.[0]?.path;
+    if (!bannerLocalPath) {
+      return res.status(400).json({
+        status: "failed",
+        error: {
+          banner: { message: "Category image is required", path: "banner" },
+        },
+      });
+    }
+
+    let banner;
+    try {
+      const uploadResponse = await uploadOnCloudinary(bannerLocalPath);
+      banner = {
+        public_id: uploadResponse.public_id,
+        url: uploadResponse.secure_url || uploadResponse.url,
+      };
+    } catch (uploadError) {
+      return res.status(500).json({
+        status: "failed",
+        error: {
+          message: "Failed to upload banner to Cloudinary",
+          details: uploadError.message,
+        },
+      });
+    }
+
+    // Create new category
+    const newCategory = new Category({
+      name: category_name,
+      url: slugify(category_url, { lower: true }),
+      description: editor,
+      metaTitle: meta_title,
+      metaDescription: meta_description,
+      status,
+      metaKeywords: meta_keywords,
+      parentCategory: parent_category ? parent_category : [],
+      banner: [banner], // Wrap in an array
+    });
+
+    // Save category to DB
+    const savedCategory = await newCategory.save();
+    res.status(201).json({ status: "successful", data: savedCategory });
+  } catch (error) {
+    console.error("Error creating category:", error);
+    res.status(error.statusCode || 500).json({
+      status: "failed",
+      error: error.message || "Internal Server Error",
+    });
+  }
+};
+
+//Category lsit
+const getCategoryList = async (req, res) => {
+  try {
+    const categories = await Category.find().sort({ createdAt: -1 });
+
+    res.status(200).json({ status: "successful", data: categories });
+  } catch (error) {
+    console.error("Error fetching categories:", error);
+    res.status(error.statusCode || 500).json({
+      status: "failed",
+      error: error.message || "Internal Server Error",
+    });
+  }
+};
+
+//get empty parent category list
+const getEmptyParentCategoryList = async (req, res) => {
+  try {
+    const categories = await Category.find({ parentCategory: [] }).sort({
+      createdAt: -1,
+    });
+
+    res.status(200).json({ status: "successful", data: categories });
+  } catch (error) {
+    console.error("Error fetching categories:", error);
+    res.status(error.statusCode || 500).json({
+      status: "failed",
+      error: error.message || "Internal Server Error",
+    });
+  }
+};
+
+// Function to check if a category exists
+async function checkIfCategoryExists(key, value) {
+  const filter = key === "name" ? { name: value } : { url: value };
+  const exists = await Category.exists(filter);
+  return !exists; // Return true if not exists, false if exists
+}
+
+// get category by id
+const getCategoryById = async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const category = await Category.findById(id);
+    if (!category) {
+      return res
+        .status(404)
+        .json({ status: "failed", error: "Category not found" });
+    }
+
+    // Fetch child categories directly using parentCategory field
+    const childCategories = await fetchChildCategory(category.parentCategory);
+
+    res.status(200).json({
+      status: "successful",
+      data: category,
+      parent: childCategories,
+      slug: category.url.replace(/-/g, " "),
+    });
+  } catch (error) {
+    console.log("Error fetching category by ID:", error);
+    res.status(error.statusCode || 500).json({
+      status: "failed",
+      error: error.message || "Internal Server Error",
+    });
+  }
+};
+
+const fetchChildCategory = async (categoryarray) => {
+  if (categoryarray[0]) {
+    try {
+      const categoryIds = categoryarray[0].split(",");
+      const objectIdArray = categoryIds.map(
+        (id) => new mongoose.Types.ObjectId(id)
+      );
+      const categories = await Category.find({ _id: { $in: objectIdArray } });
+      return categories;
+    } catch (error) {}
+  } else {
+    return [];
+  }
+};
+
+// delete category by id
+//TODO: delete image from cloudinary with delete category
+const deleteCategoryById = async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const category = await Category.findById(id);
+
+    if (!category) {
+      return res
+        .status(404)
+        .json({ status: "failed", error: "Category not found" });
+    }
+
+    // Delete the banner from Cloudinary if it exists
+    if (category.banner?.public_id) {
+      console.log(
+        "Deleting banner from Cloudinary:",
+        category.banner.public_id
+      );
+      await deleteFromCloudinary(category.banner.public_id);
+    }
+
+    // Delete the category
+    await Category.findByIdAndDelete(id);
+    res
+      .status(200)
+      .json({ status: "successful", message: "Category deleted successfully" });
+  } catch (error) {
+    console.log("Error deleting category by ID:", error);
+    res.status(error.statusCode || 500).json({
+      status: "failed",
+      error: error.message || "Internal Server Error",
+    });
+  }
+};
+
+//update category by id
+//TODO: fix update category by id and delete image from cloudinary if new image is uploaded if not then keep the old image
+const updateCategoryById = async (req, res) => {
+  const { id } = req.params;
+  const {
+    name,
+    description,
+    metaTitle,
+    metaDescription,
+    metaKeywords,
+    status,
+  } = req.body;
+
+  try {
+    const category = await Category.findById(id);
+
+    if (!category) {
+      return res
+        .status(404)
+        .json({ status: "failed", error: "Category not found" });
+    }
+
+    console.log("Current Banner:", category.banner);
+
+    let updatedBanner = category.banner; // Default to the current banner
+
+    // Check if a new banner is uploaded
+    if (req.files?.banner) {
+      const file = req.files.banner[0]; // Get the uploaded file
+
+      // Delete the old banner from Cloudinary if it exists
+      if (category.banner?.public_id) {
+        await uploadOnCloudinary.uploader.destroy(category.banner.public_id);
+      }
+
+      // Upload the new banner to Cloudinary
+      const uploadResult = await uploadOnCloudinary(file.path, {
+        folder: "categories", // Organize images in Cloudinary
+      });
+
+      updatedBanner = {
+        public_id: uploadResult.public_id,
+        url: uploadResult.secure_url,
+      };
+
+      console.log("New Banner:", updatedBanner);
+    }
+
+    // Update category fields
+    const updatedCategory = await Category.findByIdAndUpdate(
+      id,
+      {
+        name: name || category.name,
+        description: description || category.description,
+        metaTitle: metaTitle || category.metaTitle,
+        metaDescription: metaDescription || category.metaDescription,
+        metaKeywords: metaKeywords || category.metaKeywords,
+        status: status || category.status,
+        banner: updatedBanner, // Only update if changed
+      },
+      { new: true } // Return the updated document
+    );
+
+    res.status(200).json({ status: "successful", data: updatedCategory });
+  } catch (error) {
+    console.error("Error updating category by ID:", error);
+    res.status(error.statusCode || 500).json({
+      status: "failed",
+      error: error.message || "Internal Server Error",
+    });
+  }
+};
+
+// Vertical category list Electronic, Fashion, Home, etc
+const getAllFrontendCategoryList = async (req, res) => {
+  try {
+    // Fetch all active categories
+    const categories = await Category.find({ status: " Active" });
+    //console.log("categories", categories);
+
+    if (!categories.length) {
+      return res.status(200).json({ status: "successful", data: [] });
+    }
+
+    // Organize categories
+    const mainCategories = [];
+    const categoriesMap = new Map();
+
+    // Populate categoriesMap with all categories
+    categories.forEach((cat) => {
+      categoriesMap.set(cat._id.toString(), {
+        ...cat._doc,
+        subcategories: [],
+      });
+    });
+
+    // Iterate through categories and link them
+    categories.forEach((cat) => {
+      if (cat.parentCategory.length === 0) {
+        // Add to main categories if no parent
+        mainCategories.push(categoriesMap.get(cat._id.toString()));
+      } else {
+        // Link to parent category if parent exists
+        const parentCategory = categoriesMap.get(
+          cat.parentCategory[0].toString()
+        );
+        if (parentCategory) {
+          parentCategory.subcategories.push(categoriesMap.get(cat._id.toString()));
+        }
+      }
+    });
+
+    // Respond with the organized main categories
+    res.status(200).json({ status: "successful", data: mainCategories });
+  } catch (error) {
+    console.error("Error fetching all frontend categories:", error);
+    res.status(error.statusCode || 500).json({
+      status: "failed",
+      error: error.message || "Internal Server Error",
+    });
+  }
+};
+
+
+export {
+  createCategory,
+  getCategoryList,
+  getEmptyParentCategoryList,
+  getCategoryById,
+  deleteCategoryById,
+  updateCategoryById,
+  getAllFrontendCategoryList,
+};

--- a/server/lib/cloudinary.js
+++ b/server/lib/cloudinary.js
@@ -1,0 +1,47 @@
+import { v2 as cloudinary } from "cloudinary";
+import dotenv from 'dotenv'
+import fs from 'fs'
+
+dotenv.config()
+
+cloudinary.config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+    api_key: process.env.CLOUDINARY_API_KEY,
+    api_secret: process.env.CLOUDINARY_API_SECRET,
+})
+
+export const uploadOnCloudinary = async (path, retries = 3) => {
+  try {
+    if (!path) throw new Error("File path is missing");
+
+    const response = await cloudinary.uploader.upload(path, { resource_type: "auto" });
+
+    // Remove the temporary file after upload
+    fs.unlinkSync(path);
+    return response;
+  } catch (error) {
+    console.error("Cloudinary upload error:", error);
+
+    // Retry logic for timeout errors
+    if (retries > 0 && error.error?.http_code === 499) {
+      console.log(`Retrying upload... Attempts left: ${retries - 1}`);
+      return uploadOnCloudinary(path, retries - 1);
+    }
+
+    // Ensure temporary files are cleaned up in case of an error
+    if (fs.existsSync(path)) fs.unlinkSync(path);
+    return null;
+  }
+};
+
+export const deleteFromCloudinary = async (publicId) => {
+  try {
+    console.log('these is deleteFromCloudinary', publicId)
+    const result = await cloudinary.delete_resources(publicId, options).then(callback);
+    console.log(`Deleted ${publicId} from Cloudinary`);
+    return result;
+  } catch (error) {
+    console.error(`Failed to delete ${publicId} from Cloudinary`, error);
+    throw error;
+  }
+};

--- a/server/lib/cloudinaryUtils.js
+++ b/server/lib/cloudinaryUtils.js
@@ -1,0 +1,20 @@
+import fs from "fs";
+
+ export const uploadOnCloudinary = async (path) => {
+  try {
+    if (!path) throw new Error("File path is missing");
+
+    const response = await cloudinary.uploader.upload(path, { resource_type: "auto" });
+
+    // Remove the temporary file after upload
+    fs.unlinkSync(path);
+    return response;
+  } catch (error) {
+    console.error("Cloudinary upload error:", error);
+
+    // Ensure temporary files are cleaned up in case of an error
+    if (fs.existsSync(path)) fs.unlinkSync(path);
+    return null;
+  }
+};
+

--- a/server/middlewares/multer.middlewares.js
+++ b/server/middlewares/multer.middlewares.js
@@ -1,0 +1,14 @@
+import multer from "multer";
+
+
+const storage = multer.diskStorage({
+    destination: function (req, file, cb) {
+      cb(null, './public/temp'); // Save files here
+    },
+    filename: function (req, file, cb) {
+      cb(null, `${Date.now()}-${file.originalname}`); // Generate unique filenames
+    },
+  });
+  
+export const upload = multer({ storage });
+  

--- a/server/models/Product/productCategory.model.js
+++ b/server/models/Product/productCategory.model.js
@@ -1,0 +1,64 @@
+import mongoose from "mongoose";
+
+// Declare the Schema of the Mongo model for the product category
+var categorySchema = mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: [true, "name is required"],
+      unique: [true, "name must be unique"],
+      // index:true,
+    },
+    url: {
+      type: String,
+      required: [true, "name is url"],
+      unique: true,
+      lowercase: true,
+    },
+    description: {
+      type: String,
+      required: [true, "description is required"],
+    },
+    metaTitle: {
+      type: String,
+      required: [true, "title is required"],
+    },
+    metaDescription: {
+      type: String,
+      required: [true, "meta description is required"],
+    },
+    metaKeywords: {
+      type: String,
+      required: [true, "meta Keywords is required"],
+    },
+    parentCategory: {
+      type: Array,
+      default: [],
+    },
+    attribute: {
+      type: Array,
+      default: [],
+    },
+    status: {
+      type: String,
+      default: "Active",
+    },
+    banner: [
+      {
+        public_id: {
+          type: String,
+          required: true,
+        },
+        url: {
+          type: String,
+          required: true,
+        },
+      }
+    ],
+  },
+  { timestamps: true }
+);
+
+//Export the model
+const Category = mongoose.model("Category", categorySchema);
+export default Category;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -22,7 +22,8 @@
         "mailtrap": "^3.4.0",
         "mongoose": "^8.8.4",
         "multer": "^1.4.5-lts.1",
-        "nodemailer": "^6.9.16"
+        "nodemailer": "^6.9.16",
+        "slugify": "^1.6.6"
       },
       "devDependencies": {
         "nodemon": "^3.1.7"
@@ -2242,6 +2243,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/sparse-bitfield": {

--- a/server/package.json
+++ b/server/package.json
@@ -31,7 +31,8 @@
     "mailtrap": "^3.4.0",
     "mongoose": "^8.8.4",
     "multer": "^1.4.5-lts.1",
-    "nodemailer": "^6.9.16"
+    "nodemailer": "^6.9.16",
+    "slugify": "^1.6.6"
   },
   "devDependencies": {
     "nodemon": "^3.1.7"

--- a/server/routes/Product/productCategory.route.js
+++ b/server/routes/Product/productCategory.route.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import { createCategory, deleteCategoryById, getAllFrontendCategoryList, getCategoryById, getCategoryList, getEmptyParentCategoryList, updateCategoryById } from '../../controllers/product/productCategory.controllers.js';
+import { upload } from '../../middlewares/multer.middlewares.js';
+
+const router = express.Router();
+
+
+//TODO: Add your routes here
+router.post('/',upload.fields([{name: "banner", maxCount:1}]),createCategory)
+router.get('/all',getCategoryList)  //Category list items All
+router.get('/single', getEmptyParentCategoryList) //get empty parent category list items
+router.get('/list', getAllFrontendCategoryList)  //! Frontend parent( main ) category list 
+router.get('/:id', getCategoryById) //get category by id
+router.delete('/:id', deleteCategoryById) //delete category by id
+router.patch('/:id', upload.fields([{name: "banner", maxCount:1}]), updateCategoryById) //update category by id  //TODO: Need o modify the update category by id
+
+
+export default router;


### PR DESCRIPTION
Implemented routes for product category operations: 
`POST /` to create a category with banner upload functionality. GET /all to fetch all category list items.
`GET /`single to retrieve empty parent categories.
`GET /`list to fetch frontend parent categories.
`GET /:id` to fetch a category by ID.
`DELETE /:id `to delete a category by ID.
`PATCH /:id` to update a category with banner upload functionality. 
Added multer middleware for handling file uploads for createCategory and updateCategoryById. 
-setup cloudinary configuration